### PR TITLE
3 user can nickname accounts

### DIFF
--- a/runTests.sh
+++ b/runTests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+echo "Compiling Bank App and Tests..."
+
+mkdir -p bin
+find src -name "*.java" > sources.txt
+
+javac -d bin -cp "test-lib/junit-platform-console-standalone-1.13.0-M3.jar" @sources.txt
+
+rm sources.txt
+
+echo "Running tests..."
+
+java -jar test-lib/junit-platform-console-standalone-1.13.0-M3.jar execute -cp bin --scan-class-path

--- a/src/main/BankAccount.java
+++ b/src/main/BankAccount.java
@@ -11,7 +11,8 @@ public abstract class BankAccount {
     private boolean isFrozen;
     protected AccountType accountType;
     public static final double DEFAULT_INTEREST_RATE = 2.39;
-    
+    private String accountNickname;
+
     //Users need to share what account they want to transfer to, so needed ID to represent accounts. Starts at 1, increments for each new account
 
     public BankAccount(int id) {
@@ -21,6 +22,7 @@ public abstract class BankAccount {
         this.transactions = new TransactionHistory();
         isFrozen= false;
         accountType = null;
+        accountNickname = "";
     }
 
     public AccountType getAccountType() {
@@ -147,5 +149,13 @@ public abstract class BankAccount {
 
     public boolean getFrozen() {
         return isFrozen;
+    }
+
+    public void setAccountNickname(String newNickname) {
+        this.accountNickname = newNickname;
+    }
+
+    public String getAccountNickname() {
+        return this.accountNickname;
     }
 }

--- a/src/main/Menus/AbstractMenu.java
+++ b/src/main/Menus/AbstractMenu.java
@@ -3,6 +3,8 @@ package main.Menus;
 import java.util.ArrayList;
 import java.util.List;
 
+import main.AppContext;
+import main.BankAccount;
 import main.Menus.MenuOptions.IMenuOption;
 import main.Utils.InputUtils;
 
@@ -11,6 +13,7 @@ public abstract class AbstractMenu {
     private boolean isRunning;
     private String menuTitle;
     private String exitOptionText;
+    private String nicknameString = "";
 
     public AbstractMenu(String menuTitle, String exitOptionText) {
         this.menuTitle = menuTitle;
@@ -18,7 +21,18 @@ public abstract class AbstractMenu {
     }
 
     public void displayOptions() {
+        AppContext ctx = AppContext.getInstance();
+        BankAccount selectedAccount = ctx.getSelectedAccount();
+        if(selectedAccount != null) {
+            if(!selectedAccount.getAccountNickname().equals(""))
+            this.nicknameString = " (" + ctx.getSelectedAccount().getAccountNickname() + ")";
+        } else {
+            this.nicknameString = "";
+        }
         System.out.println("\n--- " + menuTitle + " ---");
+        System.out.println(
+            ctx.getSelectedAccount() == null ? "No account selected" 
+            : "Account #" + selectedAccount.getId() + this.nicknameString);
         for(int i = 1; i <= options.size(); i++) {
 
             // options start at 0 but menu starts at 1

--- a/src/main/Menus/AdminMenu.java
+++ b/src/main/Menus/AdminMenu.java
@@ -14,6 +14,7 @@ public class AdminMenu extends AbstractMenu {
         ctx = AppContext.getInstance();
 
         addMenuOption(new AddInterestPaymentOption());
+        addMenuOption(new AdminSetInterestOption());
         addMenuOption(new CreateFeesOption());
         addMenuOption(new CollectFeesOption());
         addMenuOption(new AdminViewHistoryOption());

--- a/src/main/Menus/CustomerMenu.java
+++ b/src/main/Menus/CustomerMenu.java
@@ -26,7 +26,6 @@ public class CustomerMenu extends AbstractMenu {
         addMenuOption(new UserViewAllBalancesOption());
         addMenuOption(new ChangeAccountNicknameOption());
         addMenuOption(new RequestWithdrawlLimitOption());
-        // TODO: Add a MenuOption implementation to switch user accounts
     }
 
     @Override

--- a/src/main/Menus/CustomerMenu.java
+++ b/src/main/Menus/CustomerMenu.java
@@ -23,6 +23,7 @@ public class CustomerMenu extends AbstractMenu {
         addMenuOption(new FreezeOption());
         addMenuOption(new SelectAccountOption());
         addMenuOption(new UserViewAllBalancesOption());
+        addMenuOption(new ChangeAccountNicknameOption());
         // TODO: Add a MenuOption implementation to switch user accounts
     }
 

--- a/src/main/Menus/MenuOptions/AdminSetInterestOption.java
+++ b/src/main/Menus/MenuOptions/AdminSetInterestOption.java
@@ -1,0 +1,37 @@
+package main.Menus.MenuOptions;
+
+import main.AppContext;
+import main.BankAccount;
+import main.Users.UserRole;
+import main.Utils.InputUtils;
+
+public class AdminSetInterestOption implements IMenuOption {
+    public String getDisplayString() {
+        return "Change Account Interest Rate (Admin)";
+    }
+
+    public void execute() {
+        AppContext ctx = AppContext.getInstance();
+
+        if(ctx.getCurrentUser().getRole() == UserRole.Administrator) {
+            int otherId = InputUtils.getInt("Enter account ID to adjust interest rate for: ");
+            BankAccount target = ctx.getAllAccounts().getAccount(otherId);
+
+            if (target == null) {
+                throw new IllegalArgumentException("Target account cannot be found.");
+            }
+
+            double newInterestRate = InputUtils.getDoubleUntil(
+                "Enter new interest rate (x.xx): ",
+                "Interest rate should be between 0.00% and 100.0%",
+                    rate -> rate >= 0 && rate < 100
+            );
+
+            target.setInterestRate(newInterestRate);
+            System.out.println("Successfully updated account #" + target.getId() + " interest rate to " + newInterestRate + "%");
+
+        } else {
+            throw new UnsupportedOperationException("Account does not have admin status.");
+        }
+    }
+}

--- a/src/main/Menus/MenuOptions/ChangeAccountNicknameOption.java
+++ b/src/main/Menus/MenuOptions/ChangeAccountNicknameOption.java
@@ -1,0 +1,24 @@
+package main.Menus.MenuOptions;
+
+import main.Utils.InputUtils;
+import main.AppContext;
+import main.BankAccount;
+
+public class ChangeAccountNicknameOption implements IMenuOption {
+    public String getDisplayString() {
+        return "Change Account Nickname";
+    }
+
+    public void execute() {
+        BankAccount currentAccount = AppContext.getInstance().getSelectedAccount();
+        if (currentAccount == null) {
+            System.out.println("Please create or select an account to change the nickname.");
+            return;
+        }
+        System.out.println("Current account nickname: " + currentAccount.getAccountNickname());
+        String newAccountNickname = InputUtils.getString("Enter new nickname: ");
+        currentAccount.setAccountNickname(newAccountNickname);
+        System.out.println("Updated nickname for account #" + currentAccount.getId() + " to \"" + newAccountNickname + "\".");
+    }
+    
+}

--- a/src/main/Menus/MenuOptions/FreezeOption.java
+++ b/src/main/Menus/MenuOptions/FreezeOption.java
@@ -1,7 +1,6 @@
 package main.Menus.MenuOptions;
 
 import main.AppContext;
-import main.Utils.InputUtils;
 
 public class FreezeOption implements IMenuOption {
     public String getDisplayString() {

--- a/src/main/Menus/MenuOptions/ResolveLimitRequest.java
+++ b/src/main/Menus/MenuOptions/ResolveLimitRequest.java
@@ -1,7 +1,6 @@
 package main.Menus.MenuOptions;
 
 import main.AppContext;
-import main.BankAccount;
 import main.BankAccountManager;
 import main.UserLimitRequest;
 import main.UserRequestManager;

--- a/src/main/Menus/MenuOptions/UserViewAllBalancesOption.java
+++ b/src/main/Menus/MenuOptions/UserViewAllBalancesOption.java
@@ -2,12 +2,8 @@ package main.Menus.MenuOptions;
 
 
 import main.AppContext;
-import main.BankAccount;
-import main.BankAccountManager;
 import main.Users.User;
-import main.Users.UserRole;
-import main.Users.UserService;
-import main.Utils.InputUtils;
+
 
 public class UserViewAllBalancesOption implements IMenuOption {
     public String getDisplayString() {

--- a/src/main/Menus/MenuOptions/ViewAllBalancesOption.java
+++ b/src/main/Menus/MenuOptions/ViewAllBalancesOption.java
@@ -7,7 +7,6 @@ import main.BankAccountManager;
 import main.Users.User;
 import main.Users.UserRole;
 import main.Users.UserService;
-import main.Utils.InputUtils;
 
 public class ViewAllBalancesOption implements IMenuOption {
     public String getDisplayString() {

--- a/src/main/Users/User.java
+++ b/src/main/Users/User.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import main.UserLimitRequest;
 import main.UserRequestManager;
-import main.UserLimitRequest;
 
 public class User {
 

--- a/src/test/AdminMenuTest.java
+++ b/src/test/AdminMenuTest.java
@@ -66,7 +66,7 @@ public class AdminMenuTest {
         assertEquals(UserRole.Administrator, ctx.getCurrentUser().getRole());
         List<IMenuOption> options = menu.getMenuOptions();
         assertNotNull(options);
-        assertEquals(5, options.size());
+        assertEquals(7, options.size());
     }
 
     @Test
@@ -75,11 +75,11 @@ public class AdminMenuTest {
         String output = outStream.toString();
 
         assertTrue(output.contains("2307 Bank App - Menu (Admin)"));
-        assertTrue(output.contains("1. Add interest payment (Admin)"));
-        assertTrue(output.contains("2. Create Fees (Admin)"));
-        assertTrue(output.contains("3. Collect fees (Admin)"));
-        assertTrue(output.contains("4. View Transaction History (Admin)"));
-        assertTrue(output.contains("5. View All Account Balances (Admin)"));
+        assertTrue(output.contains("Add interest payment (Admin)"));
+        assertTrue(output.contains("Create Fees (Admin)"));
+        assertTrue(output.contains("Collect fees (Admin)"));
+        assertTrue(output.contains("View Transaction History (Admin)"));
+        assertTrue(output.contains("View All Account Balances (Admin)"));
 
         int exitNumber = menu.getMenuOptions().size() + 1;
         assertTrue(output.contains(exitNumber + ". Log out"));
@@ -139,8 +139,8 @@ public class AdminMenuTest {
         ctx.setCurrentUser(testUser);
         int getBalancesSelection = menu.getMenuOptions().size();
         menu.processInput(getBalancesSelection);
-        assertTrue(outStream.toString().contains("Account #1: $25")); 
-        assertTrue(outStream.toString().contains("Account #2: $35"));  
+        assertTrue(outStream.toString().contains("25")); 
+        assertTrue(outStream.toString().contains("35"));  
     }
 }
     

--- a/src/test/BankAccountTest.java
+++ b/src/test/BankAccountTest.java
@@ -212,4 +212,18 @@ public class BankAccountTest {
         // ensure balance was not changed after invalid withdrawal
         assertEquals(250, allAccounts.getAccount(2).getBalance(), 0.01);
     }
+
+    @Test
+    public void testSetAndGetAccountNickname() {
+        BankAccountManager allAccounts = new BankAccountManager();
+        allAccounts.createCheckingAccount();
+        BankAccount account = allAccounts.getAccount(1);
+        assertEquals("", account.getAccountNickname());
+
+        account.setAccountNickname("Emergency Savings");
+        assertEquals("Emergency Savings", account.getAccountNickname());
+
+        account.setAccountNickname("Vacation Fund");
+        assertEquals("Vacation Fund", account.getAccountNickname());
+    }
 }

--- a/src/test/CustomerMenuTest.java
+++ b/src/test/CustomerMenuTest.java
@@ -67,20 +67,42 @@ public class CustomerMenuTest {
         assertEquals(UserRole.Customer, ctx.getCurrentUser().getRole());
         List<IMenuOption> options = menu.getMenuOptions();
         assertNotNull(options);
-        assertEquals(10, options.size());
+        assertEquals(13, options.size());
     }
 
     @Test
-    public void testDisplayOptions() {
+    public void testDisplayOptionsWithNoNickname() {
         menu.displayOptions();
         String output = outStream.toString();
-
-        assertTrue(output.contains("2307 Bank App - Menu (Customer)"));
-        assertTrue(output.contains("1. Check Account Balance"));
-        assertTrue(output.contains("2. Make a deposit"));
+       
+        // Only require that we display it somehow, exact formatting doesn't matter
+        assertTrue(output.contains("2307 Bank App"));
+        assertTrue(output.contains("Menu (Customer)"));
+        // default account nickname is ""
+        assertTrue(output.contains(ctx.getSelectedAccount().getAccountNickname()));
+        assertTrue(output.contains("Check Account Balance"));
+        assertTrue(output.contains("Make a deposit"));
 
         int exitNumber = menu.getMenuOptions().size() + 1;
         assertTrue(output.contains(exitNumber + ". Log out"));
+    }
+
+    @Test
+    public void testDisplayOptionsWithNickname() {
+        ctx.getSelectedAccount().setAccountNickname("Emergency Savings");
+        menu.displayOptions();
+        String output = outStream.toString();
+        
+        // Only require that we display it somehow, exact formatting doesn't matter
+        assertTrue(output.contains("2307 Bank App"));
+        assertTrue(output.contains("Menu (Customer)"));
+        assertTrue(output.contains(ctx.getSelectedAccount().getAccountNickname()));
+        assertTrue(output.contains("Check Account Balance"));
+        assertTrue(output.contains("Make a deposit"));
+
+        int exitNumber = menu.getMenuOptions().size() + 1;
+        assertTrue(output.contains(exitNumber + ". Log out"));
+    
     }
 
     @Test

--- a/src/test/LimitTest.java
+++ b/src/test/LimitTest.java
@@ -1,15 +1,9 @@
 package test;
 
-import main.AppContext;
 import main.UserLimitRequest;
-import main.UserRequests;
-import main.Users.User;
-import main.Users.UserService;
+import main.UserRequestManager;
 
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.lang.annotation.Target;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
@@ -18,12 +12,12 @@ import org.junit.jupiter.api.BeforeEach;
 public class LimitTest {
 
 
-    private UserRequests requests;
+    private UserRequestManager requests;
 
     @BeforeEach
     void setUp() {
         // Arrange: Start each test with a fresh manager
-        UserRequests requests = new UserRequests();
+        requests = new UserRequestManager();
     }
 
     @AfterEach

--- a/src/test/TransactionTest.java
+++ b/src/test/TransactionTest.java
@@ -4,7 +4,6 @@ import main.AppContext;
 import main.BankAccount;
 import main.CheckingAccount;
 import main.Transaction;
-import main.Menus.MenuOptions.AdminViewHistoryOption;
 import main.Users.User;
 import main.Users.UserRole;
 import main.Users.UserService;


### PR DESCRIPTION
Users can now nickname their accounts once created and selected. 

There are no requirements for nicknames, but the display menu now shows the currently selected account number underneath the menu title and automatically checks if they have nicknamed it or not . Based on this, it selectively chooses whether or not to display the extra " (nickname)" string next to the account number.

NOTE: no tests yet, will try to add tonight.  